### PR TITLE
Fix warning about handle_child_terminated

### DIFF
--- a/lib/acme_server/jobs/http_verifier.ex
+++ b/lib/acme_server/jobs/http_verifier.ex
@@ -27,9 +27,9 @@ defmodule AcmeServer.Jobs.HttpVerifier do
   def handle_info(other, state), do: super(other, state)
 
   @impl Parent.GenServer
-  def handle_child_terminated(:verification, _pid, :normal, state), do: {:noreply, state}
+  def handle_child_terminated(:verification, _meta, _pid, :normal, state), do: {:noreply, state}
 
-  def handle_child_terminated(:verification, _pid, _abnormal_reason, state) do
+  def handle_child_terminated(:verification, _meta, _pid, _abnormal_reason, state) do
     start_verification(state)
     {:noreply, state}
   end

--- a/lib/site_encrypt/certifier.ex
+++ b/lib/site_encrypt/certifier.ex
@@ -27,7 +27,7 @@ defmodule SiteEncrypt.Certifier do
   def handle_info(other, state), do: super(other, state)
 
   @impl Parent.GenServer
-  def handle_child_terminated(:fetcher, _pid, _reason, state) do
+  def handle_child_terminated(:fetcher, _meta, _pid, _reason, state) do
     config = state.callback.config()
     log(config, "Certbot finished")
     Process.send_after(self(), :start_fetch, config.renew_interval())

--- a/mix.lock
+++ b/mix.lock
@@ -3,8 +3,8 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
-  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
-  "parent": {:git, "https://github.com/sasa1977/parent.git", "5591220ba48d5b8658fdd94e41b7a70b135525a8", []},
-  "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "parent": {:git, "https://github.com/sasa1977/parent.git", "aa082a022ffaf04dddf8776e0f2e241209116ea6", []},
+  "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Based on `mix deps.update` on the `parent` project.  Not sure if this is locked at the specific version on purpose or not.  If yes, then PR can be declined.

```
warning: got "@impl Parent.GenServer" for function handle_child_terminated/4 but this behaviour does not specify such callback. The known callbacks are:

  * GenServer.code_change/3 (function)
  * GenServer.format_status/2 (function)
  * GenServer.handle_call/3 (function)
  * GenServer.handle_cast/2 (function)
  * Parent.GenServer.handle_child_terminated/5 (function)
  * GenServer.handle_info/2 (function)
  * GenServer.init/1 (function)
  * GenServer.terminate/2 (function)

  lib/site_encrypt/certifier.ex:30
```