### PR TITLE
Wrap tests around the Nonce generator

### DIFF
--- a/lib/acme_server.ex
+++ b/lib/acme_server.ex
@@ -145,20 +145,20 @@ defmodule AcmeServer do
 
   defp decode_request(body) do
     {:ok, request} = AcmeServer.JWS.decode(body)
-    verify_nonce(request)
+    verify_nonce!(request)
     request
   end
 
   defp client_key(request), do: Map.fetch!(request.protected, "jwk")
 
-  defp verify_nonce(request) do
+  defp verify_nonce!(request) do
     nonce =
       request.protected
       |> Map.fetch!("nonce")
       |> Base.decode64!(padding: false)
       |> String.to_integer()
 
-    AcmeServer.Nonce.verify(nonce)
+    AcmeServer.Nonce.verify!(nonce)
   end
 
   defp decode_order_path(order_path) do

--- a/lib/acme_server/nonce.ex
+++ b/lib/acme_server/nonce.ex
@@ -5,7 +5,7 @@ defmodule AcmeServer.Nonce do
     nonce
   end
 
-  def verify(nonce) do
+  def verify!(nonce) do
     AcmeServer.Db.pop!({:nonce, nonce})
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule SiteEncrypt.MixProject do
       {:plug, "~> 1.5", optional: true},
       {:jason, "~> 1.0"},
       {:jose, "~> 1.8"},
+      {:stream_data, "~> 0.1", only: [:dev, :test]},
       {:dialyxir, "~> 0.5.0", runtime: false, only: [:dev, :test]}
     ]
   end

--- a/test/acme_server/nonce_test.exs
+++ b/test/acme_server/nonce_test.exs
@@ -7,23 +7,23 @@ defmodule AcmeServer.NonceTest do
     assert nonce != first_nonce
   end
 
-  test "verify created nonce" do
+  test "verify! created nonce" do
     nonce = AcmeServer.Nonce.new()
-    assert :ok == AcmeServer.Nonce.verify(nonce)
+    assert :ok == AcmeServer.Nonce.verify!(nonce)
   end
 
-  test "verify created nonce ONLY once" do
+  test "verify! created nonce ONLY once" do
     nonce = AcmeServer.Nonce.new()
-    assert :ok == AcmeServer.Nonce.verify(nonce)
+    assert :ok == AcmeServer.Nonce.verify!(nonce)
 
     assert_raise MatchError, fn ->
-      AcmeServer.Nonce.verify(nonce)
+      AcmeServer.Nonce.verify!(nonce)
     end
   end
 
   test "verify unknown nonce throw error" do
     assert_raise MatchError, fn ->
-      AcmeServer.Nonce.verify(-1)
+      AcmeServer.Nonce.verify!(-1)
     end
   end
 end

--- a/test/acme_server/nonce_test.exs
+++ b/test/acme_server/nonce_test.exs
@@ -1,5 +1,6 @@
 defmodule AcmeServer.NonceTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   test "new is unique" do
     first_nonce = AcmeServer.Nonce.new()
@@ -21,9 +22,40 @@ defmodule AcmeServer.NonceTest do
     end
   end
 
-  test "verify unknown nonce throw error" do
+  test "verify! unknown nonce throw error" do
     assert_raise MatchError, fn ->
       AcmeServer.Nonce.verify!(-1)
+    end
+  end
+
+  # TODO: Look at adding StreamData.repeatedly to StreamData
+  # This code is based on https://elixirforum.com/t/how-to-create-a-custom-streamdata-generator/11935/9
+  defp nonce() do
+    :ignore
+    |> StreamData.constant()
+    |> StreamData.bind(fn _ -> StreamData.constant(AcmeServer.Nonce.new()) end)
+  end
+
+  property "nonce is always unique" do
+    check all nonce_a <- nonce(),
+              nonce_b <- nonce() do
+      assert nonce_a != nonce_b
+    end
+  end
+
+  property "nonce is always verifiable" do
+    check all nonce_a <- nonce() do
+      assert :ok == AcmeServer.Nonce.verify!(nonce_a)
+    end
+  end
+
+  property "nonce is can only be verified once" do
+    check all nonce_a <- nonce() do
+      :ok = AcmeServer.Nonce.verify!(nonce_a)
+
+      assert_raise MatchError, fn ->
+        AcmeServer.Nonce.verify!(nonce_a)
+      end
     end
   end
 end

--- a/test/acme_server/nonce_test.exs
+++ b/test/acme_server/nonce_test.exs
@@ -1,0 +1,29 @@
+defmodule AcmeServer.NonceTest do
+  use ExUnit.Case, async: true
+
+  test "new is unique" do
+    first_nonce = AcmeServer.Nonce.new()
+    nonce = AcmeServer.Nonce.new()
+    assert nonce != first_nonce
+  end
+
+  test "verify created nonce" do
+    nonce = AcmeServer.Nonce.new()
+    assert :ok == AcmeServer.Nonce.verify(nonce)
+  end
+
+  test "verify created nonce ONLY once" do
+    nonce = AcmeServer.Nonce.new()
+    assert :ok == AcmeServer.Nonce.verify(nonce)
+
+    assert_raise MatchError, fn ->
+      AcmeServer.Nonce.verify(nonce)
+    end
+  end
+
+  test "verify unknown nonce throw error" do
+    assert_raise MatchError, fn ->
+      AcmeServer.Nonce.verify(-1)
+    end
+  end
+end


### PR DESCRIPTION
A small refactor to change `verify` to `verify!` as it will throw an error if it is unable to pop the value off

```
iex(1)> AcmeServer.Nonce.verify!(10)
** (MatchError) no match of right hand side value: []
    (site_encrypt) lib/acme_server/db.ex:23: AcmeServer.Db.pop!/1
    (site_encrypt) lib/acme_server/nonce.ex:9: AcmeServer.Nonce.verify!/1
```