### PR TITLE
Add missing type specifications (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 site_encrypt-*.tar
 
+# Elixir Language Server output
+.elixir_ls

--- a/lib/acme_server.ex
+++ b/lib/acme_server.ex
@@ -11,6 +11,7 @@ defmodule AcmeServer do
   @type status :: pos_integer
   @type headers :: [{String.t(), String.t()}]
   @type body :: binary
+  @type domains :: [String.t()]
 
   @spec child_spec(start_opts) :: Supervisor.child_spec()
   def child_spec(opts),

--- a/lib/acme_server/account.ex
+++ b/lib/acme_server/account.ex
@@ -1,12 +1,19 @@
 defmodule AcmeServer.Account do
+  @type site :: String.t()
+  @type dns :: %{String.t() => String.t()}
+  @type config :: %{site: site, site_uri: URI.t(), dns: dns}
+
+  @spec create(config, String.t()) :: map()
   def create(config, client_key) do
     account = %{id: :erlang.unique_integer([:positive, :monotonic]), status: :valid, contact: []}
     AcmeServer.Db.store_new!(config, {:account, client_key}, account)
     account
   end
 
+  @spec fetch(config, String.t()) :: {:ok, any()} | :error
   def fetch(config, client_key), do: AcmeServer.Db.fetch(config, {:account, client_key})
 
+  @spec new_order(config, map(), list()) :: map()
   def new_order(config, account, domains) do
     order = %{
       id: :erlang.unique_integer([:positive, :monotonic]),
@@ -20,9 +27,11 @@ defmodule AcmeServer.Account do
     order
   end
 
+  @spec update_order(config, integer(), map()) :: true
   def update_order(config, account_id, order),
     do: AcmeServer.Db.store(config, {:order, account_id, order.id}, order)
 
+  @spec get_order!(config, integer(), integer()) :: any()
   def get_order!(config, account_id, order_id),
     do: AcmeServer.Db.fetch!(config, {:order, account_id, order_id})
 end

--- a/lib/acme_server/account.ex
+++ b/lib/acme_server/account.ex
@@ -1,16 +1,16 @@
 defmodule AcmeServer.Account do
-  @type t :: %{id: integer(), status: atom(), contact: list()}
+  @type t :: %{id: integer()}
   @type order :: %{
           id: integer(),
           status: :valid | :pending,
-          cert: nil,
+          cert: nil | binary(),
           domains: AcmeServer.domains(),
           token: binary()
         }
 
   @spec create(AcmeServer.config(), String.t()) :: t()
   def create(config, client_key) do
-    account = %{id: :erlang.unique_integer([:positive, :monotonic]), status: :valid, contact: []}
+    account = %{id: :erlang.unique_integer([:positive, :monotonic])}
     AcmeServer.Db.store_new!(config, {:account, client_key}, account)
     account
   end
@@ -32,7 +32,7 @@ defmodule AcmeServer.Account do
     order
   end
 
-  @spec update_order(AcmeServer.config(), integer(), map()) :: true
+  @spec update_order(AcmeServer.config(), integer(), order) :: true
   def update_order(config, account_id, order),
     do: AcmeServer.Db.store(config, {:order, account_id, order.id}, order)
 

--- a/lib/acme_server/account.ex
+++ b/lib/acme_server/account.ex
@@ -32,7 +32,7 @@ defmodule AcmeServer.Account do
     order
   end
 
-  @spec update_order(AcmeServer.config(), integer(), order) :: true
+  @spec update_order(AcmeServer.config(), integer(), order) :: :ok
   def update_order(config, account_id, order),
     do: AcmeServer.Db.store(config, {:order, account_id, order.id}, order)
 

--- a/lib/acme_server/crypto.ex
+++ b/lib/acme_server/crypto.ex
@@ -1,7 +1,7 @@
 defmodule AcmeServer.Crypto do
   @type id :: {integer(), integer()}
 
-  @spec sign_csr!(id(), binary(), list()) :: binary() | no_return()
+  @spec sign_csr!(id(), binary(), AcmeServer.domains()) :: binary() | no_return()
   def sign_csr!(id, csr, domains) do
     files = init_files(id)
 

--- a/lib/acme_server/crypto.ex
+++ b/lib/acme_server/crypto.ex
@@ -1,4 +1,7 @@
 defmodule AcmeServer.Crypto do
+  @type id :: {integer(), integer()}
+
+  @spec sign_csr!(id(), binary(), list()) :: binary() | no_return()
   def sign_csr!(id, csr, domains) do
     files = init_files(id)
 

--- a/lib/acme_server/db.ex
+++ b/lib/acme_server/db.ex
@@ -6,10 +6,10 @@ defmodule AcmeServer.Db do
   @spec store(AcmeServer.config(), any(), any()) :: true
   def store(config, key, value), do: :ets.insert(table(config), {key, value})
 
-  @spec store_new!(AcmeServer.config(), tuple(), map()) :: true | false
+  @spec store_new!(AcmeServer.config(), any(), any()) :: true | false
   def store_new!(config, key, value), do: true = :ets.insert_new(table(config), {key, value})
 
-  @spec store_new(AcmeServer.config(), tuple(), map()) :: true | false
+  @spec store_new(AcmeServer.config(), any(), any()) :: true | false
   def store_new(config, key, value), do: :ets.insert_new(table(config), {key, value})
 
   @spec fetch!(AcmeServer.config(), any()) :: any()

--- a/lib/acme_server/db.ex
+++ b/lib/acme_server/db.ex
@@ -1,17 +1,28 @@
 defmodule AcmeServer.Db do
   use GenServer
 
+  @type site :: String.t()
+  @type dns :: %{String.t() => String.t()}
+  @type config :: %{site: site, site_uri: URI.t(), dns: dns}
+
   def start_link(config), do: GenServer.start_link(__MODULE__, config)
 
+  @spec store(config, tuple(), map()) :: true
   def store(config, key, value), do: :ets.insert(table(config), {key, value})
+
+  @spec store_new!(config, tuple(), map()) :: true | false
   def store_new!(config, key, value), do: true = :ets.insert_new(table(config), {key, value})
+
+  @spec store_new(config, tuple(), map()) :: true | false
   def store_new(config, key, value), do: :ets.insert_new(table(config), {key, value})
 
+  @spec fetch!(config, any()) :: any()
   def fetch!(config, key) do
     {:ok, value} = fetch(config, key)
     value
   end
 
+  @spec fetch(config, any()) :: {:ok, any()} | :error
   def fetch(config, key) do
     case :ets.lookup(table(config), key) do
       [{^key, value}] -> {:ok, value}
@@ -19,6 +30,7 @@ defmodule AcmeServer.Db do
     end
   end
 
+  @spec pop!(config, any()) :: any()
   def pop!(config, key) do
     [{^key, value}] = :ets.take(table(config), key)
     value

--- a/lib/acme_server/db.ex
+++ b/lib/acme_server/db.ex
@@ -1,28 +1,24 @@
 defmodule AcmeServer.Db do
   use GenServer
 
-  @type site :: String.t()
-  @type dns :: %{String.t() => String.t()}
-  @type config :: %{site: site, site_uri: URI.t(), dns: dns}
-
   def start_link(config), do: GenServer.start_link(__MODULE__, config)
 
-  @spec store(config, tuple(), map()) :: true
+  @spec store(AcmeServer.config(), any(), any()) :: true
   def store(config, key, value), do: :ets.insert(table(config), {key, value})
 
-  @spec store_new!(config, tuple(), map()) :: true | false
+  @spec store_new!(AcmeServer.config(), tuple(), map()) :: true | false
   def store_new!(config, key, value), do: true = :ets.insert_new(table(config), {key, value})
 
-  @spec store_new(config, tuple(), map()) :: true | false
+  @spec store_new(AcmeServer.config(), tuple(), map()) :: true | false
   def store_new(config, key, value), do: :ets.insert_new(table(config), {key, value})
 
-  @spec fetch!(config, any()) :: any()
+  @spec fetch!(AcmeServer.config(), any()) :: any()
   def fetch!(config, key) do
     {:ok, value} = fetch(config, key)
     value
   end
 
-  @spec fetch(config, any()) :: {:ok, any()} | :error
+  @spec fetch(AcmeServer.config(), any()) :: {:ok, any()} | :error
   def fetch(config, key) do
     case :ets.lookup(table(config), key) do
       [{^key, value}] -> {:ok, value}
@@ -30,7 +26,7 @@ defmodule AcmeServer.Db do
     end
   end
 
-  @spec pop!(config, any()) :: any()
+  @spec pop!(AcmeServer.config(), any()) :: any()
   def pop!(config, key) do
     [{^key, value}] = :ets.take(table(config), key)
     value

--- a/lib/acme_server/db.ex
+++ b/lib/acme_server/db.ex
@@ -3,14 +3,18 @@ defmodule AcmeServer.Db do
 
   def start_link(config), do: GenServer.start_link(__MODULE__, config)
 
-  @spec store(AcmeServer.config(), any(), any()) :: true
-  def store(config, key, value), do: :ets.insert(table(config), {key, value})
+  @spec store(AcmeServer.config(), any(), any()) :: :ok
+  def store(config, key, value) do
+    :ets.insert(table(config), {key, value})
+    :ok
+  end
 
-  @spec store_new!(AcmeServer.config(), any(), any()) :: true | false
-  def store_new!(config, key, value), do: true = :ets.insert_new(table(config), {key, value})
+  @spec store_new!(AcmeServer.config(), any(), any()) :: :ok
+  def store_new!(config, key, value), do: :ok = store_new(config, key, value)
 
-  @spec store_new(AcmeServer.config(), any(), any()) :: true | false
-  def store_new(config, key, value), do: :ets.insert_new(table(config), {key, value})
+  @spec store_new(AcmeServer.config(), any(), any()) :: :ok | :error
+  def store_new(config, key, value),
+    do: if(:ets.insert_new(table(config), {key, value}), do: :ok, else: :error)
 
   @spec fetch!(AcmeServer.config(), any()) :: any()
   def fetch!(config, key) do

--- a/lib/acme_server/jose_jason_adapter.ex
+++ b/lib/acme_server/jose_jason_adapter.ex
@@ -1,4 +1,7 @@
 defmodule AcmeServer.JoseJasonAdapter do
+  @spec encode(term()) :: String.t() | no_return()
   def encode(input), do: Jason.encode!(input)
+
+  @spec decode(iodata()) :: term() | no_return()
   def decode(binary), do: Jason.decode!(binary)
 end

--- a/lib/acme_server/jws.ex
+++ b/lib/acme_server/jws.ex
@@ -1,4 +1,5 @@
 defmodule AcmeServer.JWS do
+  @spec decode(iodata()) :: {:ok, map()} | :error
   def decode(body) do
     data = Jason.decode!(body)
 

--- a/lib/acme_server/nonce.ex
+++ b/lib/acme_server/nonce.ex
@@ -1,10 +1,16 @@
 defmodule AcmeServer.Nonce do
+  @type site :: String.t()
+  @type dns :: %{String.t() => String.t()}
+  @type config :: %{site: site, site_uri: URI.t(), dns: dns}
+
+  @spec new(config) :: integer()
   def new(config) do
     nonce = :erlang.unique_integer([:positive, :monotonic])
     AcmeServer.Db.store_new!(config, {:nonce, nonce}, nil)
     nonce
   end
 
+  @spec verify!(config, integer()) :: :ok
   def verify!(config, nonce) do
     AcmeServer.Db.pop!(config, {:nonce, nonce})
     :ok

--- a/lib/acme_server/nonce.ex
+++ b/lib/acme_server/nonce.ex
@@ -1,16 +1,12 @@
 defmodule AcmeServer.Nonce do
-  @type site :: String.t()
-  @type dns :: %{String.t() => String.t()}
-  @type config :: %{site: site, site_uri: URI.t(), dns: dns}
-
-  @spec new(config) :: integer()
+  @spec new(AcmeServer.config()) :: integer()
   def new(config) do
     nonce = :erlang.unique_integer([:positive, :monotonic])
     AcmeServer.Db.store_new!(config, {:nonce, nonce}, nil)
     nonce
   end
 
-  @spec verify!(config, integer()) :: :ok
+  @spec verify!(AcmeServer.config(), integer()) :: :ok
   def verify!(config, nonce) do
     AcmeServer.Db.pop!(config, {:nonce, nonce})
     :ok

--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -7,8 +7,10 @@ defmodule SiteEncrypt do
           email: String.t(),
           base_folder: String.t(),
           renew_interval: pos_integer(),
-          log_level: :none | Logger.level()
+          log_level: log_level
         }
+
+  @type log_level :: :none | Logger.level()
 
   @callback config() :: config
   @callback handle_new_cert(config) :: any

--- a/lib/site_encrypt/certbot.ex
+++ b/lib/site_encrypt/certbot.ex
@@ -1,7 +1,8 @@
 defmodule SiteEncrypt.Certbot do
-  @type https_keys :: {:ok, [keyfile: String.t(), certfile: String.t(), cacertfile: String.t()]}
+  @type https_keys :: [keyfile: String.t(), certfile: String.t(), cacertfile: String.t()]
+  @type ensure_cert :: {:new_cert, String.t()} | {:no_change, String.t()} | {:error, String.t()}
 
-  @spec https_keys(map()) :: https_keys | :error
+  @spec https_keys(map()) :: {:ok, https_keys} | :error
   def https_keys(config) do
     if keys_available?(config) do
       {:ok,
@@ -15,7 +16,7 @@ defmodule SiteEncrypt.Certbot do
     end
   end
 
-  @spec ensure_cert(map) :: tuple()
+  @spec ensure_cert(SiteEncrypt.config()) :: ensure_cert()
   def ensure_cert(config) do
     ensure_folders(config)
     original_keys_sha = keys_sha(config)

--- a/lib/site_encrypt/certbot.ex
+++ b/lib/site_encrypt/certbot.ex
@@ -1,4 +1,7 @@
 defmodule SiteEncrypt.Certbot do
+  @type https_keys :: {:ok, [keyfile: String.t(), certfile: String.t(), cacertfile: String.t()]}
+
+  @spec https_keys(map()) :: https_keys | :error
   def https_keys(config) do
     if keys_available?(config) do
       {:ok,
@@ -12,6 +15,7 @@ defmodule SiteEncrypt.Certbot do
     end
   end
 
+  @spec ensure_cert(map) :: tuple()
   def ensure_cert(config) do
     ensure_folders(config)
     original_keys_sha = keys_sha(config)
@@ -28,6 +32,7 @@ defmodule SiteEncrypt.Certbot do
     end
   end
 
+  @spec challenge_file(String.t(), String.t()) :: String.t()
   def challenge_file(base_folder, challenge) do
     Path.join([
       webroot_folder(%{base_folder: base_folder}),

--- a/lib/site_encrypt/logger.ex
+++ b/lib/site_encrypt/logger.ex
@@ -1,6 +1,11 @@
 defmodule SiteEncrypt.Logger do
   require Logger
+  @type level :: :debug | :info | :warn | :error
+  @type chardata_or_fun :: [binary()] | fun()
 
+  @spec log(:none, any()) :: :ok
   def log(:none, _), do: :ok
+
+  @spec log(level, chardata_or_fun) :: :ok | {:error, any()}
   def log(level, chardata_or_fun), do: Logger.log(level, chardata_or_fun)
 end

--- a/lib/site_encrypt/logger.ex
+++ b/lib/site_encrypt/logger.ex
@@ -1,11 +1,10 @@
 defmodule SiteEncrypt.Logger do
   require Logger
-  @type level :: :debug | :info | :warn | :error
-  @type chardata_or_fun :: [binary()] | fun()
 
-  @spec log(:none, any()) :: :ok
+  @type log_fun :: (() -> Logger.message() | {Logger.message(), keyword()})
+  @type log_result :: :ok | {:error, :noproc} | {:error, term()}
+
+  @spec log(SiteEncrypt.log_level(), Logger.message() | log_fun()) :: log_result()
   def log(:none, _), do: :ok
-
-  @spec log(level, chardata_or_fun) :: :ok | {:error, any()}
   def log(level, chardata_or_fun), do: Logger.log(level, chardata_or_fun)
 end

--- a/lib/site_encrypt/phoenix.ex
+++ b/lib/site_encrypt/phoenix.ex
@@ -1,16 +1,5 @@
 defmodule SiteEncrypt.Phoenix do
-  @type config :: %{
-          run_client?: boolean,
-          ca_url: String.t() | {:local_acme_server, %{port: pos_integer, adapter: module}},
-          domain: String.t(),
-          extra_domains: [String.t()],
-          email: String.t(),
-          base_folder: String.t(),
-          renew_interval: pos_integer(),
-          log_level: :none | Logger.level()
-        }
-
-  @spec child_spec(tuple()) :: map()
+  @spec child_spec({module, module}) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{id: __MODULE__, type: :supervisor, start: {__MODULE__, :start_link, [opts]}}
   end
@@ -30,10 +19,11 @@ defmodule SiteEncrypt.Phoenix do
     )
   end
 
-  @spec restart_endpoint(config) :: tuple()
+  @spec restart_endpoint(SiteEncrypt.config()) :: :ok
   def restart_endpoint(config) do
     Supervisor.terminate_child(name(config), :endpoint)
     Supervisor.restart_child(name(config), :endpoint)
+    :ok
   end
 
   defp name(config), do: SiteEncrypt.Registry.via_tuple({__MODULE__, config.domain})

--- a/lib/site_encrypt/phoenix.ex
+++ b/lib/site_encrypt/phoenix.ex
@@ -1,4 +1,16 @@
 defmodule SiteEncrypt.Phoenix do
+  @type config :: %{
+          run_client?: boolean,
+          ca_url: String.t() | {:local_acme_server, %{port: pos_integer, adapter: module}},
+          domain: String.t(),
+          extra_domains: [String.t()],
+          email: String.t(),
+          base_folder: String.t(),
+          renew_interval: pos_integer(),
+          log_level: :none | Logger.level()
+        }
+
+  @spec child_spec(tuple()) :: map()
   def child_spec(opts) do
     %{id: __MODULE__, type: :supervisor, start: {__MODULE__, :start_link, [opts]}}
   end
@@ -18,6 +30,7 @@ defmodule SiteEncrypt.Phoenix do
     )
   end
 
+  @spec restart_endpoint(config) :: tuple()
   def restart_endpoint(config) do
     Supervisor.terminate_child(name(config), :endpoint)
     Supervisor.restart_child(name(config), :endpoint)


### PR DESCRIPTION
This PR aims to add type specs to (almost) all functions that were lacking them, with the purpose of resolving issue https://github.com/sasa1977/site_encrypt/issues/9 .

More specifically, this PR currently aims to add type specifications to functions where the function input/output is not immediately clear. This means that I've not yet touched much on the internal functions that are used to implement e.g. GenServer behaviour. As per the issue, no private functions are specced either.

Additionally, as many editors run the Elixir language server for in-editor Dialyzer, this commit also adds the ElixirLS output directory to the .gitignore. This can obviously be amended after review if it's not a desired addition.

One known issue that certainly requires review is on the file `lib/acme_server/db.ex`, where I've currently used `any()` types to represent terms returned from ETS (I didn't quite follow which possible types can be stored or returned here). Obviously this isn't adequately accurate for our type specs, but I wanted to make an initial PR for review now rather than stall the issue much longer. 