### PR TITLE
Upgrade x509 package

### DIFF
--- a/lib/acme_server/crypto.ex
+++ b/lib/acme_server/crypto.ex
@@ -4,7 +4,7 @@ defmodule AcmeServer.Crypto do
 
   @spec sign_csr!(binary(), AcmeServer.domains()) :: binary() | no_return()
   def sign_csr!(der, domains) do
-    csr = X509.from_der(der, :CertificationRequest)
+    csr = CSR.from_der!(der)
     unless CSR.valid?(csr), do: raise("CSR validation failed")
 
     {ca_key, ca_cert} = ca_key_and_cert()
@@ -12,7 +12,7 @@ defmodule AcmeServer.Crypto do
     csr
     |> CSR.public_key()
     |> server_cert(ca_key, ca_cert, domains)
-    |> X509.to_pem()
+    |> Certificate.to_pem()
   end
 
   def self_signed_chain(domains) do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule SiteEncrypt.MixProject do
       {:plug, "~> 1.5", optional: true},
       {:jason, "~> 1.0"},
       {:jose, "~> 1.8"},
-      {:x509, "~> 0.1"},
+      {:x509, "~> 0.3"},
       {:stream_data, "~> 0.1", only: [:dev, :test]},
       {:dialyxir, "~> 0.5.0", runtime: false, only: [:dev, :test]}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,5 @@
   "parent": {:hex, :parent, "0.4.1", "9ec330408dbe1f63fe82668a60ad2ef8af05df8440a54ebebf44e91eb16ff261", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
-  "x509": {:hex, :x509, "0.1.0", "f913ec0be8fc53cd7b0faf3f4eaf6e5c437dcf5d9219d30cd3174c3f38b1e608", [:mix], [], "hexpm"},
+  "x509": {:hex, :x509, "0.3.0", "c6f3db66960c6e4f424d1e6cca5c7d730e0a577af8dc115a613f4560ce1df6d3", [:mix], [], "hexpm"},
 }

--- a/phoenix_demo/mix.lock
+++ b/phoenix_demo/mix.lock
@@ -16,5 +16,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "site_encrypt": {:git, "https://github.com/sasa1977/site_encrypt.git", "96bf87108eb90ae2237ebe553dae0b892df9a947", []},
-  "x509": {:hex, :x509, "0.1.1", "99224d4a0a66147c91c2a23cf252140208085ebf00faf3edc90354f87c1968d8", [:mix], [], "hexpm"},
+  "x509": {:hex, :x509, "0.3.0", "c6f3db66960c6e4f424d1e6cca5c7d730e0a577af8dc115a613f4560ce1df6d3", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
I'm preparing to change some of the public API of the X509 package. In v0.3.0 I introduced some new functions that already conform to the new API, and in some upcoming release I will change the behaviour of existing functions. Please see [v0.3.0 release notes](https://github.com/voltone/x509/releases/tag/v0.3.0) for details.

This PR updates the dependency to 0.3.0 and uses the new API that is intended to be stable going forward, to ensure site_encrypt will not be affected by those future changes.