### PR TITLE
Future proof for x509 v0.4.0

### DIFF
--- a/lib/acme_server/crypto.ex
+++ b/lib/acme_server/crypto.ex
@@ -25,7 +25,11 @@ defmodule AcmeServer.Crypto do
       |> PublicKey.derive()
       |> server_cert(ca_key, ca_cert, domains)
 
-    %{ca_cert: ca_cert, server_cert: server_cert, server_key: server_key}
+    %{
+      ca_cert: Certificate.to_pem(ca_cert),
+      server_cert: Certificate.to_pem(server_cert),
+      server_key: PrivateKey.to_pem(server_key)
+    }
   end
 
   defp ca_key_and_cert() do

--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -58,7 +58,7 @@ defmodule SiteEncrypt do
 
     [config.domain | config.extra_domains]
     |> AcmeServer.Crypto.self_signed_chain()
-    |> Stream.map(fn {type, entity} -> {file_name(type), X509.to_pem(entity)} end)
+    |> Stream.map(fn {type, pem} -> {file_name(type), pem} end)
     |> Enum.each(&save_pem!(config, &1))
   end
 


### PR DESCRIPTION

A method from the x509 library has been removed

https://github.com/voltone/x509/commit/02aa79e3244deee42c3b0371b21cbc4ec8f05a6d

## v0.4.0
 ### Breaking changes
   * [X509] Removed `to_der/1`, `to_pem/1` and `from_der/2`

I have updated the library to use the underlying function, to reproduce the issue run `mix deps.update --all` and then you will see the following warning

```
warning: function X509.to_pem/1 is undefined or private
  lib/site_encrypt.ex:61
```

Or, drop the latest code in production and then see tihngs blow up.


