### PR TITLE
Upgrading to Phoenix 1.4 -- Support Jason parser and updated Plug.Cowboy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,20 @@ defmodule PhoenixDemoWeb.Certbot do
     :ok
   end
 
+  # If you are running original Cowboy (Phoenix 1.3 or less), then use this implementation
   defp local_acme_server(), do: {:local_acme_server, %{adapter: Plug.Adapters.Cowboy, port: 4002}}
+
+  # Or, if Cowboy2
+  defp local_acme_server(), do: {:local_acme_server, %{adapter: Plug.Adapters.Cowboy2, port: 4002}}
+
+  # If you have upgraded to Phoenix 1.4, then reference Cowboy directly
+  # But, buyer beware, if you are also using `Jason` for your JSON encoder/decoder
+  # Then check on the status of this PR (or a similar one) to add that support
+  # https://github.com/potatosalad/erlang-jose/pull/58/files
+  # If it's still not merged and/or released, you might need to reference that branch
+  # directly in your mix.exs
+  # {:jose, override: true, github: "hauleth/erlang-jose", branch: "patch-1"},
+  defp local_acme_server(), do: {:local_acme_server, %{adapter: Plug.Cowboy, port: 4002}}
 end
 ```
 

--- a/lib/acme_server/jws.ex
+++ b/lib/acme_server/jws.ex
@@ -25,8 +25,7 @@ defmodule AcmeServer.JWS do
       [{_jwk, [{true, payload, _jws}]}] ->
         {:ok, %{payload: Jason.decode!(payload), protected: protected}}
 
-      _ ->
-        :error
+        error -> error
     end
   end
 end

--- a/lib/acme_server/standalone.ex
+++ b/lib/acme_server/standalone.ex
@@ -11,10 +11,12 @@ defmodule AcmeServer.Standalone do
 
   defp port(Cowboy, adapter_opts), do: cowboy_port(adapter_opts)
   defp port(Cowboy2, adapter_opts), do: cowboy_port(adapter_opts)
+  defp port(Plug.Cowboy, adapter_opts), do: cowboy_port(adapter_opts)
 
   defp cowboy_port(adapter_opts),
     do: adapter_opts |> Keyword.fetch!(:options) |> Keyword.fetch!(:port)
 
   defp adapter_spec(Cowboy, adapter_opts), do: Cowboy.child_spec(adapter_opts)
   defp adapter_spec(Cowboy2, adapter_opts), do: Cowboy2.child_spec(adapter_opts)
+  defp adapter_spec(Plug.Cowboy, adapter_opts), do: Plug.Cowboy.child_spec(adapter_opts)
 end

--- a/lib/site_encrypt/phoenix.ex
+++ b/lib/site_encrypt/phoenix.ex
@@ -36,7 +36,7 @@ defmodule SiteEncrypt.Phoenix do
   end
 
   defp acme_server_adapter_spec(Plug.Adapters.Cowboy, port),
-    do: {Plug.Adapters.Cowboy, scheme: :http, options: [port: port, acceptors: 1]}
+    do: {Plug.Adapters.Cowboy, scheme: :http, options: [port: port, transport_options: [num_acceptors: 1]]}
 
   defp dns(config, endpoint) do
     [config.domain | config.extra_domains]

--- a/lib/site_encrypt/phoenix.ex
+++ b/lib/site_encrypt/phoenix.ex
@@ -35,8 +35,8 @@ defmodule SiteEncrypt.Phoenix do
     )
   end
 
-  defp acme_server_adapter_spec(Plug.Adapters.Cowboy, port),
-    do: {Plug.Adapters.Cowboy, scheme: :http, options: [port: port, transport_options: [num_acceptors: 1]]}
+  defp acme_server_adapter_spec(adapter, port),
+    do: {adapter, scheme: :http, options: [port: port, transport_options: [num_acceptors: 1]]}
 
   defp dns(config, endpoint) do
     [config.domain | config.extra_domains]


### PR DESCRIPTION

When upgrading Phoenix 1.4, I noticed the following warning

```
warning: using :acceptors in options is deprecated. Please pass :num_acceptors to the :transport_options keyword list instead
```

In addressing that, a few other issues surfaced.

Phoenix 1.4 uses plug_cowboy (instead of cowboy directly) and defaults to Jason JSON parser; resulting in two additional issues.

First, I passed the adapter directly through in `acme_server_adapter_spec` (instead of just using the Cowboy adapter).

Second, it wasn't clear about the next error, so I am passing it through (instead of just replying `:error`), so that it was clearer that the issue was `{:error, :unsupported_json_module}`

Third, I updated the README documentation to include a workaround to keep Jason as the parser (which needs a specific branch of `jose` to run).