### PR TITLE
Support https-only endpoints

### DIFF
--- a/lib/site_encrypt/phoenix.ex
+++ b/lib/site_encrypt/phoenix.ex
@@ -113,7 +113,15 @@ defmodule SiteEncrypt.Phoenix do
   end
 
   defp endpoint_port(%{id: endpoint}) do
-    if server?(endpoint), do: endpoint.config(:http) |> Keyword.fetch!(:port)
+    if server?(endpoint) && http?(endpoint), do: endpoint.config(:http) |> Keyword.fetch!(:port)
+  end
+
+  defp http?(endpoint) do
+    case endpoint.config(:http) do
+      false -> false
+      [] -> false
+      _ -> true
+    end
   end
 
   defp server?(endpoint) do


### PR DESCRIPTION
An endpoint that is only https will likely have `false` as the `:http` configuration, which is the default:
https://hexdocs.pm/phoenix/1.5.8/Phoenix.Endpoint.html?#module-adapter-configuration

Without this you get an error like:
```
11:18:57.256 [error] GenServer GenTrackerWeb.Endpoint terminating
** (FunctionClauseError) no function clause matching in Keyword.fetch!/2
    (elixir 1.12.0-rc.0) lib/keyword.ex:417: Keyword.fetch!(false, :port)
    (site_encrypt 0.4.2) lib/site_encrypt/phoenix.ex:106: SiteEncrypt.Phoenix.start_acme_server/1
    (parent 0.12.0) lib/parent.ex:646: Parent.start_validated_child/2
    (parent 0.12.0) lib/parent.ex:375: Parent.start_child/2
    (parent 0.12.0) lib/parent.ex:396: anonymous fn/1 in Parent.start_all_children!/1
```