### PR TITLE
Add change-detection for list of domains and `expand` functionality in certbot client

### DIFF
--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -372,7 +372,7 @@ defmodule SiteEncrypt do
       certificate <- X509.Certificate.from_pem!(pems.cert),
       {:Extension, _, _, dns_names} <- X509.Certificate.extension(certificate, :subject_alt_name),
       certificate_subjects <- dns_names |> Enum.map(fn {_, dns_name} -> to_string(dns_name) end) |> Enum.sort(),
-      domains <- Map.get(SiteEncrypt.Registry.config(AnitaDomainRedirectWeb.Endpoint), :domains) |> Enum.sort()
+      domains <- config.domains |> Enum.sort()
     do
       domains != certificate_subjects
     else

--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -368,15 +368,36 @@ defmodule SiteEncrypt do
   current set of domains.
   """
   def certificate_subjects_changed?(config) do
-    with {:ok, pems} <- SiteEncrypt.client(config).pems(config),
-      certificate <- X509.Certificate.from_pem!(pems.cert),
-      {:Extension, _, _, dns_names} <- X509.Certificate.extension(certificate, :subject_alt_name),
-      certificate_subjects <- dns_names |> Enum.map(fn {_, dns_name} -> to_string(dns_name) end) |> Enum.sort(),
-      domains <- config.domains |> Enum.sort()
-    do
-      domains != certificate_subjects
-    else
+    case domains_certified(config) do
+      {:ok, certificate_subjects} -> config.domains |> Enum.sort() != certificate_subjects |> Enum.sort()
       _ -> false
     end
+  end
+
+  @doc """
+  Retrieve a list of domains secured by the current certificate (via section `subject_alt_name`)
+  Returns either {:ok, certificate_subjects} or :error
+  """
+  def domains_certified(config) do
+    with {:ok, pems} <- SiteEncrypt.client(config).pems(config),
+         certificate <- X509.Certificate.from_pem!(pems.cert),
+         {:Extension, _, _, dns_names} <- X509.Certificate.extension(certificate, :subject_alt_name),
+         certificate_subjects <- dns_names |> Enum.map(fn {_, dns_name} -> to_string(dns_name) end)
+    do
+      {:ok, certificate_subjects}
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Refresh the configuration for a given endpoint.
+
+  Use this if your endpoint is dynamically retrieving the list of domains from the database for example and you want to
+  update the configuration in the registry. In most cases it makes sense to call `SiteEncrypt.force_certify/1` after
+  the config has been refreshed.
+  """
+  def refresh_config(id) do
+    SiteEncrypt.Adapter.refresh_config(id)
   end
 end

--- a/lib/site_encrypt/acme/server.ex
+++ b/lib/site_encrypt/acme/server.ex
@@ -34,8 +34,7 @@ defmodule SiteEncrypt.Acme.Server do
   end
 
   def whereis(id) do
-    root = SiteEncrypt.Registry.root(id)
-    {:ok, server} = Parent.Client.child_pid(root, __MODULE__)
+    {:ok, server} = Parent.Client.child_pid(SiteEncrypt.Registry.root(id), __MODULE__)
     server
   end
 

--- a/lib/site_encrypt/adapter.ex
+++ b/lib/site_encrypt/adapter.ex
@@ -43,6 +43,13 @@ defmodule SiteEncrypt.Adapter do
     GenServer.call(Registry.root(id), :start_all_children)
   end
 
+  @doc """
+  Refresh the configuration for a given endpoint
+  """
+  def refresh_config(id) do
+    GenServer.call(Registry.root(id), :refresh_config)
+  end
+
   @impl GenServer
   def init({callback, id, arg}) do
     state = %{callback: callback, id: id, arg: arg}
@@ -53,6 +60,13 @@ defmodule SiteEncrypt.Adapter do
   @impl GenServer
   def handle_call(:start_all_children, _from, state) do
     start_all_children!(state)
+    {:reply, :ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:refresh_config, _from, state) do
+    adapter_config = state.callback.config(state.id, state.arg)
+    Registry.store_config(state.id, adapter_config.certification)
     {:reply, :ok, state}
   end
 

--- a/lib/site_encrypt/adapter.ex
+++ b/lib/site_encrypt/adapter.ex
@@ -1,0 +1,94 @@
+defmodule SiteEncrypt.Adapter do
+  alias SiteEncrypt.{Acme, Registry}
+
+  use Parent.GenServer
+
+  @callback config(SiteEncrypt.id(), arg :: any) :: %{
+              certification: SiteEncrypt.certification(),
+              site_spec: Parent.child_spec()
+            }
+
+  @callback http_port(SiteEncrypt.id(), arg :: any) :: {:ok, pos_integer} | :error
+
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
+      @behaviour SiteEncrypt.Adapter
+
+      @doc """
+      Returns a specification to start this module under a supervisor.
+
+      See `Supervisor`.
+      """
+      def child_spec(start_opts) do
+        Supervisor.child_spec(
+          %{
+            id: __MODULE__,
+            type: :supervisor,
+            start: {__MODULE__, :start_link, [start_opts]}
+          },
+          unquote(opts)
+        )
+      end
+    end
+  end
+
+  def start_link(callback, id, arg),
+    do: Parent.GenServer.start_link(__MODULE__, {callback, id, arg}, name: Registry.root(id))
+
+  @doc false
+  # used only in tests
+  def restart_site(id, fun) do
+    Parent.Client.shutdown_all(Registry.root(id))
+    fun.()
+    GenServer.call(Registry.root(id), :start_all_children)
+  end
+
+  @impl GenServer
+  def init({callback, id, arg}) do
+    state = %{callback: callback, id: id, arg: arg}
+    start_all_children!(state)
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:start_all_children, _from, state) do
+    start_all_children!(state)
+    {:reply, :ok, state}
+  end
+
+  defp start_all_children!(state) do
+    adapter_config = state.callback.config(state.id, state.arg)
+    Registry.store_config(state.id, adapter_config.certification)
+
+    SiteEncrypt.initialize_certs(adapter_config.certification)
+
+    Parent.start_all_children!([
+      Parent.child_spec(adapter_config.site_spec, id: :site),
+      Parent.child_spec(Acme.Server,
+        start: fn -> start_acme_server(state, adapter_config) end,
+        binds_to: [:site]
+      )
+      | SiteEncrypt.Certification.child_specs(state.id)
+    ])
+  end
+
+  defp start_acme_server(state, adapter_config) do
+    config = adapter_config.certification
+
+    with {:ok, site_port} <- state.callback.http_port(state.id, state.arg),
+         {:ok, acme_server_port} when not is_nil(acme_server_port) <- acme_server_port(config) do
+      dns = dns(config, site_port)
+      Acme.Server.start_link(config.id, acme_server_port, dns, log_level: config.log_level)
+    else
+      _ -> :ignore
+    end
+  end
+
+  defp acme_server_port(%{directory_url: {:internal, acme_server_opts}}),
+    do: Keyword.fetch(acme_server_opts, :port)
+
+  defp acme_server_port(_), do: :error
+
+  defp dns(config, endpoint_port),
+    do: Enum.into(config.domains, %{}, &{&1, fn -> "localhost:#{endpoint_port}" end})
+end

--- a/lib/site_encrypt/certification.ex
+++ b/lib/site_encrypt/certification.ex
@@ -88,7 +88,7 @@ defmodule SiteEncrypt.Certification do
     config = Registry.config(id)
 
     if config.mode == :auto do
-      if Periodic.cert_due_for_renewal?(config) do
+      if Periodic.cert_due_for_renewal?(config) || SiteEncrypt.certificate_subjects_changed?(config) do
         start_renew(config)
       else
         SiteEncrypt.log(config, [

--- a/lib/site_encrypt/certification.ex
+++ b/lib/site_encrypt/certification.ex
@@ -10,9 +10,9 @@ defmodule SiteEncrypt.Certification do
         id: __MODULE__.InitialRenewal,
         start: {Task, :start_link, [fn -> start_initial_renewal(id) end]},
         restart: :temporary,
-        binds_to: [:endpoint]
+        binds_to: [:site]
       },
-      Parent.child_spec({Periodic, id}, binds_to: [:endpoint])
+      Parent.child_spec({Periodic, id}, binds_to: [:site])
     ]
   end
 
@@ -101,7 +101,9 @@ defmodule SiteEncrypt.Certification do
   end
 
   defp start_renew(config) do
-    root = Registry.root(config.id)
-    Parent.Client.start_child(root, {SiteEncrypt.Certification.Job, config})
+    Parent.Client.start_child(
+      Registry.root(config.id),
+      {SiteEncrypt.Certification.Job, config}
+    )
   end
 end

--- a/lib/site_encrypt/certification/certbot.ex
+++ b/lib/site_encrypt/certification/certbot.ex
@@ -29,7 +29,7 @@ defmodule SiteEncrypt.Certification.Certbot do
     ensure_folders(config)
 
     result = case pems(config) do
-      {:ok, pems} ->
+      {:ok, _} ->
         if SiteEncrypt.certificate_subjects_changed?(config), do: expand(config, opts), else: renew(config, opts)
       _ ->
         certonly(config, opts)

--- a/lib/site_encrypt/certification/job.ex
+++ b/lib/site_encrypt/certification/job.ex
@@ -43,7 +43,7 @@ defmodule SiteEncrypt.Certification.Job do
       timeout: :timer.minutes(5),
       restart: :temporary,
       ephemeral?: true,
-      binds_to: [:endpoint]
+      binds_to: [:site]
     }
   end
 end

--- a/lib/site_encrypt/phoenix.ex
+++ b/lib/site_encrypt/phoenix.ex
@@ -8,11 +8,17 @@ defmodule SiteEncrypt.Phoenix do
   2. Configure https via `configure_https/2`.
   3. Add the implementation of `c:SiteEncrypt.certification/0` to the endpoint (the
     `@behaviour SiteEncrypt` is injected when this module is used).
-
+  4. Start the endpoint by providing `{SiteEncrypt.Phoenix, PhoenixDemo.Endpoint}` as a supervisor child.
   """
 
-  use Parent.Supervisor
-  alias SiteEncrypt.{Acme, Registry}
+  use SiteEncrypt.Adapter
+  alias SiteEncrypt.Adapter
+
+  @spec child_spec(endpoint :: module) :: Supervisor.child_spec()
+
+  @doc "Starts the endpoint managed by `SiteEncrypt`."
+  @spec start_link(endpoint :: module) :: Supervisor.on_start()
+  def start_link(endpoint), do: Adapter.start_link(__MODULE__, endpoint, endpoint)
 
   @doc """
   Merges paths to key and certificates to the `:https` configuration of the endpoint config.
@@ -67,61 +73,21 @@ defmodule SiteEncrypt.Phoenix do
     end
   end
 
-  @doc false
-  def start_link(endpoint) do
-    Parent.Supervisor.start_link(
-      children(endpoint),
-      name: {:via, Elixir.Registry, {Registry, endpoint}}
-    )
+  @impl Adapter
+  def config(_id, endpoint) do
+    %{
+      certification: endpoint.certification(),
+      site_spec: endpoint.child_spec([])
+    }
   end
 
-  @doc false
-  def restart_site(endpoint, fun) do
-    root = Registry.root(endpoint)
-    Parent.Client.shutdown_all(root)
-    fun.()
-    Enum.each(children(endpoint), fn spec -> {:ok, _} = Parent.Client.start_child(root, spec) end)
-  end
-
-  defp children(endpoint) do
-    [
-      Parent.child_spec(endpoint, id: :endpoint, start: fn -> start_endpoint(endpoint) end),
-      Parent.child_spec(Acme.Server,
-        start: fn -> start_acme_server(endpoint) end,
-        binds_to: [:endpoint]
-      )
-    ] ++ SiteEncrypt.Certification.child_specs(endpoint)
-  end
-
-  defp start_endpoint(endpoint) do
-    config = endpoint.certification()
-    Registry.store_config(endpoint, config)
-    SiteEncrypt.initialize_certs(config)
-    endpoint.start_link([])
-  end
-
-  defp start_acme_server(endpoint) do
-    config = Registry.config(endpoint)
-
-    with endpoint_port when not is_nil(endpoint_port) <- endpoint_port(config),
-         port when not is_nil(port) <- acme_server_port(config) do
-      dns = dns(config, endpoint_port)
-      Acme.Server.start_link(config.id, port, dns, log_level: config.log_level)
-    else
-      _ -> :ignore
-    end
-  end
-
-  defp endpoint_port(%{id: endpoint}) do
-    if server?(endpoint), do: http_port(endpoint)
-  end
-
-  defp http_port(endpoint) do
+  @impl Adapter
+  def http_port(_id, endpoint) do
     http_config = endpoint.config(:http)
 
     with true <- Keyword.keyword?(http_config),
          port when is_integer(port) <- Keyword.get(http_config, :port) do
-      port
+      {:ok, port}
     else
       _ ->
         raise_http_required(http_config)
@@ -130,21 +96,13 @@ defmodule SiteEncrypt.Phoenix do
 
   defp raise_http_required(http_config) do
     raise "Unable to retrieve HTTP port from the HTTP configuration. SiteEncrypt relies on the Lets Encrypt " <>
-            "HTTP-01 challenge type which requires an HTTP version of the endpoint to be running and " <>
-            "the configuration received did not include an http port.\n" <>
-            "Received: #{inspect(http_config)}"
+          "HTTP-01 challenge type which requires an HTTP version of the endpoint to be running and " <>
+          "the configuration received did not include an http port.\n" <>
+          "Received: #{inspect(http_config)}"
   end
 
   defp server?(endpoint) do
-    with nil <- endpoint.config(:server),
-         do: Application.get_env(:phoenix, :serve_endpoints, false)
+    endpoint.config(:server) ||
+      Application.get_env(:phoenix, :serve_endpoints, false)
   end
-
-  defp dns(config, endpoint_port),
-    do: Enum.into(config.domains, %{}, &{&1, fn -> "localhost:#{endpoint_port}" end})
-
-  defp acme_server_port(%{directory_url: {:internal, acme_server_opts}}),
-    do: Keyword.get(acme_server_opts, :port)
-
-  defp acme_server_port(_), do: nil
 end

--- a/lib/site_encrypt/phoenix/test.ex
+++ b/lib/site_encrypt/phoenix/test.ex
@@ -34,7 +34,7 @@ defmodule SiteEncrypt.Phoenix.Test do
   """
   @spec clean_restart(module) :: :ok
   def clean_restart(endpoint) do
-    SiteEncrypt.Phoenix.restart_site(endpoint, fn ->
+    SiteEncrypt.Adapter.restart_site(endpoint, fn ->
       ~w/db_folder backup/a
       |> Stream.map(&Map.fetch!(endpoint.certification(), &1))
       |> Stream.reject(&is_nil/1)

--- a/lib/site_encrypt/registry.ex
+++ b/lib/site_encrypt/registry.ex
@@ -4,7 +4,7 @@ defmodule SiteEncrypt.Registry do
   def child_spec(_),
     do: Supervisor.child_spec({Registry, keys: :unique, name: __MODULE__}, id: __MODULE__)
 
-  def root(id), do: GenServer.whereis({:via, Registry, {__MODULE__, id}})
+  def root(id), do: {:via, Registry, {__MODULE__, id}}
 
   def store_config(id, config) do
     {_, _} = Registry.update_value(__MODULE__, id, fn _ -> config end)

--- a/test/site_encrypt_test.exs
+++ b/test/site_encrypt_test.exs
@@ -37,7 +37,7 @@ for {client, index} <- Enum.with_index([:native, :certbot]),
       assert File.exists?(config.backup)
 
       # remove db folder and restart the site
-      SiteEncrypt.Phoenix.restart_site(TestEndpoint, fn ->
+      SiteEncrypt.Adapter.restart_site(TestEndpoint, fn ->
         File.rm_rf!(config.db_folder)
         :ssl.clear_pem_cache()
       end)

--- a/test/site_encrypt_test.exs
+++ b/test/site_encrypt_test.exs
@@ -50,6 +50,13 @@ for {client, index} <- Enum.with_index([:native, :certbot]),
       refute get_cert(TestEndpoint) == first_cert
     end
 
+    test "detect change in domains" do
+      config = SiteEncrypt.Registry.config(TestEndpoint)
+      updated_config = config |> update_in([:domains], fn domains -> domains ++ ["bar.localhost"] end)
+      
+      assert true == SiteEncrypt.certificate_subjects_changed?(updated_config)
+    end
+
     defmodule TestEndpoint do
       @moduledoc false
 


### PR DESCRIPTION
Hi,

I'm running a tiny service with `Phoenix` and `SiteEncrypt` where an admin can add domains via a separate endpoint which should redirect to several marketing deep-URLs. As I didn't want to fiddle around with a webserver in front of the service including all the letsencrypt hassle I installed `SiteEncrypt` in my service but soon found out, that it wouldn't request new certificates whenever I added a domain and ran `SiteEncrypt.force_certify/1`.

Therefore I've added `SiteEncrypt.certificate_subjects_changed?/1` which checks for a change between the domains of the configuration and the domains (i.e. `subject_alt_name`) of the certificate.

I've added that check in `SiteEncrypt.Certification.start_initial_renewal/1` after the call to `Periodic.cert_due_for_renewal?/1` in order to kick off the renewal.

Within the renewal of the certbot client I've added the call to `SiteEncrypt.certificate_subjects_changed?/1` again to decide whether we need to run `SiteEncrypt.Certification.Certbot.certonly/2` or a newly introduced `SiteEncrypt.Certification.Certbot.expand/2`. The latter only differing from the former by the argument `--expand` in the cli command.

Please let me know what you think.

Thank you and best regards,
Alex