### PR TITLE
Updates RSA keys since TLS1.3 requires size >= 2048

### DIFF
--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -194,7 +194,7 @@ defmodule SiteEncrypt do
         |> Map.merge(unquote(Macro.escape(overrides)))
         |> Map.update!(:backup, &(&1 && Path.expand(&1)))
 
-      if SiteEncrypt.local_ca?(config), do: %{config | key_size: 1024}, else: config
+      if SiteEncrypt.local_ca?(config), do: %{config | key_size: 2048}, else: config
     end
   end
 

--- a/lib/site_encrypt/acme/server.ex
+++ b/lib/site_encrypt/acme/server.ex
@@ -259,7 +259,7 @@ defmodule SiteEncrypt.Acme.Server do
   end
 
   defp endpoint_spec(adapter, config, port) do
-    key = X509.PrivateKey.new_rsa(1024)
+    key = X509.PrivateKey.new_rsa(2048)
     cert = X509.Certificate.self_signed(key, "/C=US/ST=CA/O=Acme/CN=ECDSA Root CA")
 
     adapter_spec = adapter_spec(adapter, config, port, key, cert)

--- a/lib/site_encrypt/acme/server/crypto.ex
+++ b/lib/site_encrypt/acme/server/crypto.ex
@@ -23,7 +23,7 @@ defmodule SiteEncrypt.Acme.Server.Crypto do
   def self_signed_chain(domains) do
     {ca_key, ca_cert} = ca_key_and_cert()
 
-    server_key = PrivateKey.new_rsa(1024)
+    server_key = PrivateKey.new_rsa(2048)
 
     server_cert =
       server_key
@@ -38,7 +38,7 @@ defmodule SiteEncrypt.Acme.Server.Crypto do
   end
 
   defp ca_key_and_cert() do
-    ca_key = PrivateKey.new_rsa(1024)
+    ca_key = PrivateKey.new_rsa(2048)
     ca_cert = Certificate.self_signed(ca_key, "/O=Site Encrypt/CN=Acme Server CA", template: :ca)
     {ca_key, ca_cert}
   end


### PR DESCRIPTION
Trying to connect to a site using a 1028-sized RSA key with `:ssl.connect({127, 0, 0, 1}, 4001, [])` caused the handshake to fail with `:unacceptable_rsa_key`.

This fixes #51