### PR TITLE
Adapt to :ssl.connect new default

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.2
-elixir 1.14.3-otp-25
+erlang 26.0
+elixir 1.15-otp-26

--- a/lib/site_encrypt/phoenix/test.ex
+++ b/lib/site_encrypt/phoenix/test.ex
@@ -58,7 +58,7 @@ defmodule SiteEncrypt.Phoenix.Test do
   """
   @spec get_cert(module) :: %{der: binary, issuer: String.t(), domains: [String.t()]}
   def get_cert(endpoint) do
-    {:ok, socket} = :ssl.connect('localhost', https_port(endpoint), [], :timer.seconds(5))
+    {:ok, socket} = :ssl.connect('localhost', https_port(endpoint), [{:verify, :verify_none}], :timer.seconds(5))
     {:ok, der_cert} = :ssl.peercert(socket)
     :ssl.close(socket)
     cert = X509.Certificate.from_der!(der_cert)

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule SiteEncrypt.MixProject do
       {:plug_cowboy, "~> 2.5", optional: true},
       {:plug, "~> 1.7", optional: true},
       {:stream_data, "~> 0.1", only: [:dev, :test]},
-      {:x509, "~> 0.3"}
+      {:x509, "~> 0.8.8"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -31,5 +31,5 @@
   "thousand_island": {:hex, :thousand_island, "0.6.7", "3a91a7e362ca407036c6691e8a4f6e01ac8e901db3598875863a149279ac8571", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "541a5cb26b88adf8d8180b6b96a90f09566b4aad7a6b3608dcac969648cf6765"},
   "websock": {:hex, :websock, "0.5.0", "f6bbce90226121d62a0715bca7c986c5e43de0ccc9475d79c55381d1796368cc", [:mix], [], "hexpm", "b51ac706df8a7a48a2c622ee02d09d68be8c40418698ffa909d73ae207eb5fb8"},
   "websock_adapter": {:hex, :websock_adapter, "0.5.0", "cea35d8bbf1a6964e32d4b02ceb561dfb769c04f16d60d743885587e7d2ca55b", [:mix], [{:bandit, "~> 0.6", [hex: :bandit, repo: "hexpm", optional: true]}, {:plug, "~> 1.14", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.6", [hex: :plug_cowboy, repo: "hexpm", optional: true]}, {:websock, "~> 0.5", [hex: :websock, repo: "hexpm", optional: false]}], "hexpm", "16318b124effab8209b1eb7906c636374f623dc9511a8278ad09c083cea5bb83"},
-  "x509": {:hex, :x509, "0.8.5", "22b2c5dfc87b05d46595d3764f41a23fcb7360f891e0464f1a2ec118177cd4e4", [:mix], [], "hexpm", "c63eb89e8bbe8a5e21b6404ad1082faff670e38b74960297f90d023177949e07"},
+  "x509": {:hex, :x509, "0.8.8", "aaf5e58b19a36a8e2c5c5cff0ad30f64eef5d9225f0fd98fb07912ee23f7aba3", [:mix], [], "hexpm", "ccc3bff61406e5bb6a63f06d549f3dba3a1bbb456d84517efaaa210d8a33750f"},
 }


### PR DESCRIPTION
Unit testing certification fails ssl handshaking when using a `.tool-versions` file wih erlang 26.0 and elixir 1.15-otp-26. This is due to erlang :ssl client using :verify_peer as the new default option since v11.0.

- Using {:verify, :verify_none} option (used to be the default option but was replaced by :verify_peer in [:ssl v11.0](https://www.erlang.org/doc/apps/ssl/notes#ssl-11.0))
- Upgrade X509 to v0.8.8 to avoid dep [compilation problem for elixir 1.15+](https://github.com/voltone/x509/pull/60)