### PR TITLE
allow new log levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- drop support for Elixir < v1.16
+- [allow](https://github.com/sasa1977/site_encrypt/pull/63) all `Logger.levels()` in `:log_level` option
+
 ## 0.6.0
 
 **Breaking**: changed the endpoint setup. Previously the client code had to configure https via the `Phoenix.Endpoint.init/2` callback. However, this callback is deprecated in the latest Phoenix, which now favours passing endpoint options via an argument to `start_link/1` (or `child_spec/1`). This style was previously not supported by site_encrypt.
@@ -74,18 +79,18 @@ This version upgrades to the Parent 0.11 and changes the internals. Strictly spe
 
 - The interface for writing tests has been changed. A certification test should now be written as
 
-    ```elixir
-    defmodule MyEndpoint.CertificationTest do
-      use ExUnit.Case, async: false
-      import SiteEncrypt.Phoenix.Test
+  ```elixir
+  defmodule MyEndpoint.CertificationTest do
+    use ExUnit.Case, async: false
+    import SiteEncrypt.Phoenix.Test
 
-      test "certification" do
-        clean_restart(MyEndpoint)
-        cert = get_cert(MyEndpoint)
-        assert cert.domains == ~w/mysite.com www.mysite.com/
-      end
+    test "certification" do
+      clean_restart(MyEndpoint)
+      cert = get_cert(MyEndpoint)
+      assert cert.domains == ~w/mysite.com www.mysite.com/
     end
-    ```
+  end
+  ```
 
 ## 0.1.0
 
@@ -99,16 +104,16 @@ This version introduces many breaking changes. If you've been using a pre 0.1 ve
 1. In your endpoint, replace `@behaviour SiteEncrypt` with `use SiteEncrypt.Phoenix`
 2. Also in the endpoint, change the `certification/0` callback to pass the options to `SiteEncrypt.configure/1` instead of just returning them.
 3. Changes in options:
-    - `:mode` is no longer supported. Manual mode will be automatically set in tests.
-    - use `:domains` instead of `:domain` and `:extra_domain`
-    - `:ca_url` has been renamed to `directory_url`
-    - `:email` has been renamed to `emails` and must be a list
-    - `:base_folder` has been renamed to `:db_folder`
-    - `:cert_folder` is no longer supported. It will chosen automatically inside the `:db_folder`
+   - `:mode` is no longer supported. Manual mode will be automatically set in tests.
+   - use `:domains` instead of `:domain` and `:extra_domain`
+   - `:ca_url` has been renamed to `directory_url`
+   - `:email` has been renamed to `emails` and must be a list
+   - `:base_folder` has been renamed to `:db_folder`
+   - `:cert_folder` is no longer supported. It will chosen automatically inside the `:db_folder`
 4. The internal folders structure has been changed. If you're running a site_encrypt system in production, you need to create the folder called `certbot` inside the `:db_folder`, and recurisvely copy top-level folders under `:db_folder` into the newly created `certbot` folder.
 5. If you have been using `SiteEncrypt.Phoenix.Test.verify_certification` for certification testing, drop that test, and add the following module somewhere in your test suite:
-    ```elixir
-    defmodule CertificationTest do
-      use SiteEncrypt.Phoenix.Test, endpoint: MyEndpoint
-    end
-    ```
+   ```elixir
+   defmodule CertificationTest do
+     use SiteEncrypt.Phoenix.Test, endpoint: MyEndpoint
+   end
+   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,18 +79,18 @@ This version upgrades to the Parent 0.11 and changes the internals. Strictly spe
 
 - The interface for writing tests has been changed. A certification test should now be written as
 
-  ```elixir
-  defmodule MyEndpoint.CertificationTest do
-    use ExUnit.Case, async: false
-    import SiteEncrypt.Phoenix.Test
+    ```elixir
+    defmodule MyEndpoint.CertificationTest do
+      use ExUnit.Case, async: false
+      import SiteEncrypt.Phoenix.Test
 
-    test "certification" do
-      clean_restart(MyEndpoint)
-      cert = get_cert(MyEndpoint)
-      assert cert.domains == ~w/mysite.com www.mysite.com/
+      test "certification" do
+        clean_restart(MyEndpoint)
+        cert = get_cert(MyEndpoint)
+        assert cert.domains == ~w/mysite.com www.mysite.com/
+      end
     end
-  end
-  ```
+    ```
 
 ## 0.1.0
 
@@ -104,16 +104,16 @@ This version introduces many breaking changes. If you've been using a pre 0.1 ve
 1. In your endpoint, replace `@behaviour SiteEncrypt` with `use SiteEncrypt.Phoenix`
 2. Also in the endpoint, change the `certification/0` callback to pass the options to `SiteEncrypt.configure/1` instead of just returning them.
 3. Changes in options:
-   - `:mode` is no longer supported. Manual mode will be automatically set in tests.
-   - use `:domains` instead of `:domain` and `:extra_domain`
-   - `:ca_url` has been renamed to `directory_url`
-   - `:email` has been renamed to `emails` and must be a list
-   - `:base_folder` has been renamed to `:db_folder`
-   - `:cert_folder` is no longer supported. It will chosen automatically inside the `:db_folder`
+    - `:mode` is no longer supported. Manual mode will be automatically set in tests.
+    - use `:domains` instead of `:domain` and `:extra_domain`
+    - `:ca_url` has been renamed to `directory_url`
+    - `:email` has been renamed to `emails` and must be a list
+    - `:base_folder` has been renamed to `:db_folder`
+    - `:cert_folder` is no longer supported. It will chosen automatically inside the `:db_folder`
 4. The internal folders structure has been changed. If you're running a site_encrypt system in production, you need to create the folder called `certbot` inside the `:db_folder`, and recurisvely copy top-level folders under `:db_folder` into the newly created `certbot` folder.
 5. If you have been using `SiteEncrypt.Phoenix.Test.verify_certification` for certification testing, drop that test, and add the following module somewhere in your test suite:
-   ```elixir
-   defmodule CertificationTest do
-     use SiteEncrypt.Phoenix.Test, endpoint: MyEndpoint
-   end
-   ```
+    ```elixir
+    defmodule CertificationTest do
+      use SiteEncrypt.Phoenix.Test, endpoint: MyEndpoint
+    end
+    ```

--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -47,6 +47,13 @@ defmodule SiteEncrypt do
   @doc "Invoked after the new certificate has been obtained."
   @callback handle_new_cert() :: any
 
+  log_levels =
+    if Version.compare(System.version(), "1.11.0") in [:gt, :eq] do
+      [:error, :info, :debug, :emergency, :alert, :critical, :warning, :notice]
+    else
+      [:debug, :info, :warn, :error]
+    end
+
   @certification_schema [
     client: [
       type: {:in, [:native, :certbot]},
@@ -114,7 +121,7 @@ defmodule SiteEncrypt do
       """
     ],
     log_level: [
-      type: {:in, Logger.levels()},
+      type: {:in, log_levels},
       default: :info,
       doc: "Logger level for info messages."
     ],

--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -114,7 +114,7 @@ defmodule SiteEncrypt do
       """
     ],
     log_level: [
-      type: {:in, [:debug, :info, :warn, :error]},
+      type: {:in, Logger.levels()},
       default: :info,
       doc: "Logger level for info messages."
     ],

--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -47,13 +47,6 @@ defmodule SiteEncrypt do
   @doc "Invoked after the new certificate has been obtained."
   @callback handle_new_cert() :: any
 
-  log_levels =
-    if Version.compare(System.version(), "1.11.0") in [:gt, :eq] do
-      [:error, :info, :debug, :emergency, :alert, :critical, :warning, :notice]
-    else
-      [:debug, :info, :warn, :error]
-    end
-
   @certification_schema [
     client: [
       type: {:in, [:native, :certbot]},
@@ -121,7 +114,7 @@ defmodule SiteEncrypt do
       """
     ],
     log_level: [
-      type: {:in, log_levels},
+      type: {:in, Logger.levels()},
       default: :info,
       doc: "Logger level for info messages."
     ],

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule SiteEncrypt.MixProject do
     [
       app: :site_encrypt,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [


### PR DESCRIPTION
👋 

I'd like to use NOTICE log level for SiteEncrypt messages and this PR should allow that. I'm not sure when if `Logger.levels/0` was available in Elixir v1.10, but I'll try to find out.

---

Seems to be available only since v1.16.0 https://hexdocs.pm/logger/1.17.0/Logger.html#levels/0, I'll hardcode it then.

---

The extended log levels were made available in v1.11.0 https://hexdocs.pm/logger/1.11.0/Logger.html#module-levels