### PR TITLE
unnest endpoint_opts in tests to fix some ci failures

### DIFF
--- a/.github/workflows/site_encrypt.yaml
+++ b/.github/workflows/site_encrypt.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-elixir@v1
         with:
           otp-version: 27.0
-          elixir-version: 1.17.0
+          elixir-version: 1.17.1
 
       - name: Restore cached deps
         uses: actions/cache@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.0
-elixir 1.16-otp-26
+erlang 27.0
+elixir 1.17.1-otp-27

--- a/test/site_encrypt_test.exs
+++ b/test/site_encrypt_test.exs
@@ -30,12 +30,10 @@ for {input, index} <- Enum.with_index(inputs),
     setup_all do
       start_supervised!({
         TestEndpoint,
-        endpoint_opts: [
-          adapter: unquote(input.adapter),
-          http: [port: unquote(http_port)],
-          https: [port: unquote(https_port)],
-          url: [scheme: "https", host: "localhost", port: unquote(https_port)]
-        ]
+        adapter: unquote(input.adapter),
+        http: [port: unquote(http_port)],
+        https: [port: unquote(https_port)],
+        url: [scheme: "https", host: "localhost", port: unquote(https_port)]
       })
 
       :ok


### PR DESCRIPTION
This PR should fix at least some of the failing tests. Comments inline.