### PR TITLE
validate_directory_url: fix error return

### DIFF
--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -348,9 +348,9 @@ defmodule SiteEncrypt do
     port = Keyword.get(opts, :port)
 
     cond do
-      is_nil(port) -> "missing port for the internal CA server"
-      not is_integer(port) -> "port for the internal CA server must be an integer"
-      port <= 0 -> "port for the internal CA server must be a positive integer"
+      is_nil(port) -> {:error, "missing port for the internal CA server"}
+      not is_integer(port) -> {:error, "port for the internal CA server must be an integer"}
+      port <= 0 -> {:error, "port for the internal CA server must be a positive integer"}
       true -> {:ok, internal}
     end
   end


### PR DESCRIPTION
Hello,

This fixes errors returned by `validate_directory_url` when matching on `{:internal, opts}`. NimbleOptions expects either `{:ok, internal}` or `{:error, "reason"}` but the latter was missing the error tuple.

Encountered error was : 
![image](https://github.com/sasa1977/site_encrypt/assets/15968815/cb745f53-bedb-4461-b96c-dfc91ca4c899)
