### PR TITLE
fix: Log all configured domains instead of only the first one

### DIFF
--- a/lib/site_encrypt.ex
+++ b/lib/site_encrypt.ex
@@ -263,6 +263,10 @@ defmodule SiteEncrypt do
   end
 
   @doc false
+  @spec domain_names(config) :: String.t()
+  def domain_names(config), do: Enum.join(config.domains, ", ")
+
+  @doc false
   @spec log(config, iodata) :: :ok
   def log(config, chardata_or_fun), do: Logger.log(config.log_level, chardata_or_fun)
 

--- a/lib/site_encrypt/certification.ex
+++ b/lib/site_encrypt/certification.ex
@@ -63,7 +63,7 @@ defmodule SiteEncrypt.Certification do
     if not is_nil(config.backup) and
          File.exists?(config.backup) and
          not File.exists?(config.db_folder) do
-      SiteEncrypt.log(config, "restoring certificates for #{hd(config.domains)}")
+      SiteEncrypt.log(config, "restoring certificates for #{SiteEncrypt.domain_names(config)}")
       File.mkdir_p!(config.db_folder)
 
       :ok =
@@ -74,7 +74,7 @@ defmodule SiteEncrypt.Certification do
 
       with {:ok, pems} <- SiteEncrypt.client(config).pems(config) do
         SiteEncrypt.set_certificate(config.id, pems)
-        SiteEncrypt.log(config, "certificates for #{hd(config.domains)} restored")
+        SiteEncrypt.log(config, "certificates for #{SiteEncrypt.domain_names(config)} restored")
       end
     end
   catch
@@ -93,7 +93,7 @@ defmodule SiteEncrypt.Certification do
         start_renew(config)
       else
         SiteEncrypt.log(config, [
-          "Certificate for #{hd(config.domains)} is valid until ",
+          "Certificate for #{SiteEncrypt.domain_names(config)} is valid until ",
           "#{Periodic.cert_valid_until(config)}. ",
           "Next renewal is scheduled for #{Periodic.renewal_date(config)}."
         ])

--- a/lib/site_encrypt/certification/job.ex
+++ b/lib/site_encrypt/certification/job.ex
@@ -15,7 +15,7 @@ defmodule SiteEncrypt.Certification.Job do
 
     case SiteEncrypt.client(config).certify(config, opts) do
       :error ->
-        Logger.error("Error obtaining certificate for #{hd(config.domains)}")
+        Logger.error("Error obtaining certificate for #{SiteEncrypt.domain_names(config)}")
         :error
 
       :ok ->

--- a/lib/site_encrypt/certification/native.ex
+++ b/lib/site_encrypt/certification/native.ex
@@ -48,10 +48,10 @@ defmodule SiteEncrypt.Certification.Native do
   end
 
   defp create_certificate(config, session) do
-    log(config, "Ordering a new certificate for domain #{hd(config.domains)}")
+    log(config, "Ordering a new certificate for domain(s) #{SiteEncrypt.domain_names(config)}")
     {pems, _session} = Client.create_certificate(session, config.id)
     store_pems!(config, pems)
-    log(config, "New certificate for domain #{hd(config.domains)} obtained")
+    log(config, "New certificate for domain(s) #{SiteEncrypt.domain_names(config)} obtained")
   end
 
   defp account_key(config) do


### PR DESCRIPTION
Hi, I had a problem debugging my app that uses this library to get the lets encrypt certs. Many thanks for the work on it, it works really well!  

The problem was that the logs would always say something like 
```
Ordering a new certificate for domain <domain> 
```
and I was thinking it wasn't ordering for the rest of domains configured. But nope, it worked fine, it was just the log that was wrong. So in this PR I properly log all the domains not only the first one.